### PR TITLE
Added `animateBackWith` to `PhysicsController` for compatibility with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6-dev.0
+
+* Added `animateBackWith` to `PhysicsController` for compatibility with new `AnimationController` API in Flutter 3.29 (master).
+
 ## 0.0.5
 
 * `PhysicsController` now implements the `AnimationController` interface, so it can (really) be used as a drop-in replacement for `AnimationController`.

--- a/lib/src/controllers/physics_controller.dart
+++ b/lib/src/controllers/physics_controller.dart
@@ -809,6 +809,18 @@ class PhysicsController extends Animation<double>
       duration: duration,
     );
   }
+
+  @override
+  TickerFuture animateBackWith(Simulation simulation) {
+    assert(
+      _ticker != null,
+      'PhysicsController.animateBackWith() called after PhysicsController.dispose()\n'
+      'PhysicsController methods should not be used after calling dispose.',
+    );
+    stop();
+    _direction = _AnimationDirection.reverse;
+    return _startSimulation(simulation);
+  }
 }
 
 /// The direction in which an animation is running.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_physics
 description: "A Flutter package providing physics-based animations including customizable spring and gravity simulations that can be used both as physics simulations and animation curves."
-version: 0.0.5
+version: 0.0.6-dev.0
 homepage: https://github.com/sangddn/flutter_physics
 repository: https://github.com/sangddn/flutter_physics
 issue_tracker: https://github.com/sangddn/flutter_physics/issues


### PR DESCRIPTION
… new `AnimationController` API in Flutter 3.29 (master)

Closes #5